### PR TITLE
feat: add annotation to mark outgoing http(s) traffic

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,12 @@
 
     <dependencies>
         <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+            <version>2.1.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>1.18.24</version>

--- a/src/java/main/com/hlag/tools/commvis/analyzer/annotation/VisualizeHttpsCall.java
+++ b/src/java/main/com/hlag/tools/commvis/analyzer/annotation/VisualizeHttpsCall.java
@@ -1,0 +1,38 @@
+package com.hlag.tools.commvis.analyzer.annotation;
+
+import javax.ws.rs.HttpMethod;
+import java.lang.annotation.*;
+
+/**
+ * Annotated on methods to indicate that an HTTP(S) call is done. Based on this information projects communicating
+ * with each other can be visualized.
+ *
+ * The destination endpoint is matched on projectId, method and path. The names of the path parameters do not have to
+ * match.
+ *
+ * @see VisualizeHttpsCalls
+ */
+@Repeatable(VisualizeHttpsCalls.class)
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface VisualizeHttpsCall {
+    /**
+     * @return the method used to call path.
+     */
+    HttpMethod method();
+
+    /**
+     * @return the path called, e.g. "/customer/{id}"
+     */
+    String path();
+
+    /**
+     * @return the project called
+     */
+    String projectId();
+
+    /**
+     * @return the name of the project called. Just for a better visibility in the code. The value isn't used.
+     */
+    String projectName() default "";
+}

--- a/src/java/main/com/hlag/tools/commvis/analyzer/annotation/VisualizeHttpsCalls.java
+++ b/src/java/main/com/hlag/tools/commvis/analyzer/annotation/VisualizeHttpsCalls.java
@@ -1,0 +1,9 @@
+package com.hlag.tools.commvis.analyzer.annotation;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface VisualizeHttpsCalls {
+    VisualizeHttpsCall[] value();
+}

--- a/src/java/main/com/hlag/tools/commvis/analyzer/service/IScannerService.java
+++ b/src/java/main/com/hlag/tools/commvis/analyzer/service/IScannerService.java
@@ -1,5 +1,6 @@
 package com.hlag.tools.commvis.analyzer.service;
 
+import com.hlag.tools.commvis.analyzer.annotation.VisualizeHttpsCall;
 import com.hlag.tools.commvis.analyzer.model.ISenderReceiverCommunication;
 
 import java.util.Collection;


### PR DESCRIPTION
# Description

Add an annotation (`VisualizeHttpsCall`) to indicate methods which do an HTTP(S) call. The annotation is repeatable in case mulitple calls are done.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
