### PR TITLE
fix: use `String` as `method` in `VisualizeHttpsCall`

### DIFF
--- a/src/java/main/com/hlag/tools/commvis/analyzer/annotation/VisualizeHttpsCall.java
+++ b/src/java/main/com/hlag/tools/commvis/analyzer/annotation/VisualizeHttpsCall.java
@@ -17,9 +17,9 @@ import java.lang.annotation.*;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface VisualizeHttpsCall {
     /**
-     * @return the method used to call path.
+     * @return the method used to call path, e.g. GET, POST, ...
      */
-    HttpMethod method();
+    String method();
 
     /**
      * @return the path called, e.g. "/customer/{id}"


### PR DESCRIPTION
# Description

Better to use a `String` instead of `HttpMethod` in the `VisualizeHttpsCall` annotation.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
