### PR TITLE
chore: decouple the internal model names from the generated JSON

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
     <scm>
         <connection>scm:git:git://github.com/Hapag-Lloyd/dist-comm-vis.git</connection>
-        <developerConnection>scm:git:ssh://github.com:Hapag-Lloyd/dist-comm-vis.git</developerConnection>
+        <developerConnection>scm:git:ssh://gitHub.com:Hapag-Lloyd/dist-comm-vis.git</developerConnection>
         <url>https://github.com/Hapag-Lloyd/dist-comm-vis/tree/main</url>
     </scm>
 
@@ -81,7 +81,7 @@
         </profile>
     </profiles>
     <build>
-        <sourceDirectory>src/java/main</sourceDirectory>
+        <sourceDirectory>src/main/java</sourceDirectory>
 
         <plugins>
             <plugin>
@@ -141,7 +141,37 @@
         </plugins>
     </build>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.8.2</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.9.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.22.0</version>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>javax.ws.rs</groupId>
             <artifactId>javax.ws.rs-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -81,8 +81,6 @@
         </profile>
     </profiles>
     <build>
-        <sourceDirectory>src/main/java</sourceDirectory>
-
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -137,6 +135,16 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>3.2.2</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>2.22.0</version>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/com/hlag/tools/commvis/analyzer/model/CommunicationModel.java
+++ b/src/main/java/com/hlag/tools/commvis/analyzer/model/CommunicationModel.java
@@ -1,5 +1,6 @@
 package com.hlag.tools.commvis.analyzer.model;
 
+import com.google.gson.annotations.SerializedName;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;
@@ -19,14 +20,19 @@ public class CommunicationModel {
     /**
      * Identifier for the current project, e.g. gitlab project id
      */
+    @SerializedName(value="projectId")
     private String projectId;
+
     /**
      * A name for the project. Just for information.
      */
+    @SerializedName(value="projectName")
     private String projectName;
+
     /**
      * All sender and receiver endpoints found.
      */
+    @SerializedName(value="endpoints")
     private Collection<ISenderReceiverCommunication> endpoints;
 
     public void visit(AbstractCommunicationModelVisitor visitor) {

--- a/src/main/java/com/hlag/tools/commvis/analyzer/model/HttpConsumer.java
+++ b/src/main/java/com/hlag/tools/commvis/analyzer/model/HttpConsumer.java
@@ -1,5 +1,6 @@
 package com.hlag.tools.commvis.analyzer.model;
 
+import com.google.gson.annotations.SerializedName;
 import lombok.*;
 
 /**
@@ -7,10 +8,14 @@ import lombok.*;
  */
 @Value
 public class HttpConsumer implements ISenderReceiverCommunication {
+    @SerializedName(value="className")
     private final String className;
+    @SerializedName(value="methodName")
     private final String methodName;
 
+    @SerializedName(value="type")
     private final String type;
+    @SerializedName(value="path")
     private final String path;
 
     @Override

--- a/src/main/java/com/hlag/tools/commvis/analyzer/model/HttpProducer.java
+++ b/src/main/java/com/hlag/tools/commvis/analyzer/model/HttpProducer.java
@@ -1,5 +1,6 @@
 package com.hlag.tools.commvis.analyzer.model;
 
+import com.google.gson.annotations.SerializedName;
 import lombok.Value;
 
 /**
@@ -10,23 +11,31 @@ public class HttpProducer implements ISenderReceiverCommunication {
     /**
      * The full qualified classname where the producer lives.
      */
+    @SerializedName(value="className")
     private final String className;
+
     /**
      * The method name of the producer.
      */
+    @SerializedName(value="methodName")
     private final String methodName;
 
     /**
      * The HTTP method like GET or POST.
      */
+    @SerializedName(value="type")
     private final String type;
+
     /**
      * The full path name called (usually without a domain).
      */
+    @SerializedName(value="path")
     private final String path;
+
     /**
      * The project id of the referenced project.
      */
+    @SerializedName(value="destinationProjectId")
     private final String destinationProjectId;
 
     @Override

--- a/src/main/java/com/hlag/tools/commvis/analyzer/model/JmsReceiver.java
+++ b/src/main/java/com/hlag/tools/commvis/analyzer/model/JmsReceiver.java
@@ -1,5 +1,6 @@
 package com.hlag.tools.commvis.analyzer.model;
 
+import com.google.gson.annotations.SerializedName;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -13,10 +14,15 @@ import lombok.ToString;
 @ToString
 @EqualsAndHashCode
 public class JmsReceiver implements ISenderReceiverCommunication {
+    @SerializedName(value="className")
     private String className;
+
     // e.g. "javax.jms.Queue"
+    @SerializedName(value="destinationType")
     private String destinationType;
+
     // e.g. "jms/catalogs/customer"
+    @SerializedName(value="destination")
     private String destination;
 
     @Override

--- a/src/test/java/com/hlag/tools/commvis/analyzer/model/CommunicationModelTest.java
+++ b/src/test/java/com/hlag/tools/commvis/analyzer/model/CommunicationModelTest.java
@@ -1,0 +1,21 @@
+package com.hlag.tools.commvis.analyzer.model;
+
+import com.google.gson.annotations.SerializedName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CommunicationModelTest {
+    @Test
+    void shouldHaveSerializedNameAnnotationOnFiled_toDecoupleTheFieldNameFromJson() {
+        Field[] declaredFields = CommunicationModel.class.getDeclaredFields();
+
+        for (Field f : declaredFields) {
+            SerializedName actualAnnotation = f.getAnnotation(SerializedName.class);
+
+            assertThat(actualAnnotation).isNotNull();
+        }
+    }
+}

--- a/src/test/java/com/hlag/tools/commvis/analyzer/model/HttpConsumerTest.java
+++ b/src/test/java/com/hlag/tools/commvis/analyzer/model/HttpConsumerTest.java
@@ -1,0 +1,21 @@
+package com.hlag.tools.commvis.analyzer.model;
+
+import com.google.gson.annotations.SerializedName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HttpConsumerTest {
+    @Test
+    void shouldHaveSerializedNameAnnotationOnFiled_toDecoupleTheFieldNameFromJson() {
+        Field[] declaredFields = CommunicationModel.class.getDeclaredFields();
+
+        for (Field f : declaredFields) {
+            SerializedName actualAnnotation = f.getAnnotation(SerializedName.class);
+
+            assertThat(actualAnnotation).isNotNull();
+        }
+    }
+}

--- a/src/test/java/com/hlag/tools/commvis/analyzer/model/HttpProducerTest.java
+++ b/src/test/java/com/hlag/tools/commvis/analyzer/model/HttpProducerTest.java
@@ -1,0 +1,21 @@
+package com.hlag.tools.commvis.analyzer.model;
+
+import com.google.gson.annotations.SerializedName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HttpProducerTest {
+    @Test
+    void shouldHaveSerializedNameAnnotationOnFiled_toDecoupleTheFieldNameFromJson() {
+        Field[] declaredFields = CommunicationModel.class.getDeclaredFields();
+
+        for (Field f : declaredFields) {
+            SerializedName actualAnnotation = f.getAnnotation(SerializedName.class);
+
+            assertThat(actualAnnotation).isNotNull();
+        }
+    }
+}

--- a/src/test/java/com/hlag/tools/commvis/analyzer/model/JmsReceiverTest.java
+++ b/src/test/java/com/hlag/tools/commvis/analyzer/model/JmsReceiverTest.java
@@ -1,0 +1,21 @@
+package com.hlag.tools.commvis.analyzer.model;
+
+import com.google.gson.annotations.SerializedName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JmsReceiverTest {
+    @Test
+    void shouldHaveSerializedNameAnnotationOnFiled_toDecoupleTheFieldNameFromJson() {
+        Field[] declaredFields = CommunicationModel.class.getDeclaredFields();
+
+        for (Field f : declaredFields) {
+            SerializedName actualAnnotation = f.getAnnotation(SerializedName.class);
+
+            assertThat(actualAnnotation).isNotNull();
+        }
+    }
+}


### PR DESCRIPTION
# Description

Enforce the usage of `@SerializedName` on the model fields to decouple the JSON representation from the internal name of the fields.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
