### PR TITLE
refactor: use one method to add endpoints only

### DIFF
--- a/src/main/java/com/hlag/tools/commvis/analyzer/model/CommunicationModel.java
+++ b/src/main/java/com/hlag/tools/commvis/analyzer/model/CommunicationModel.java
@@ -51,16 +51,16 @@ public class CommunicationModel {
     @SerializedName(value="jms_consumers")
     private Collection<ISenderReceiverCommunication> jmsConsumers = new HashSet<>();
 
-    public void addHttpConsumer(ISenderReceiverCommunication consumer) {
-        httpConsumers.add(consumer);
-    }
-
-    public void addHttpProducer(ISenderReceiverCommunication producer) {
-        httpProducers.add(producer);
-    }
-
-    public void addJmsConsumer(ISenderReceiverCommunication consumer) {
-        jmsConsumers.add(consumer);
+    public <T extends ISenderReceiverCommunication> void addSenderReceiver(T endpoint) {
+        if (endpoint instanceof HttpConsumer) {
+            httpConsumers.add(endpoint);
+        } else if (endpoint instanceof HttpProducer) {
+            httpProducers.add(endpoint);
+        } else if (endpoint instanceof JmsReceiver) {
+            jmsConsumers.add(endpoint);
+        } else {
+            throw new IllegalStateException(String.format("We have no endpoints of type %s", endpoint.getClass().getCanonicalName()));
+        }
     }
 
     public void visit(AbstractCommunicationModelVisitor visitor) {

--- a/src/main/java/com/hlag/tools/commvis/analyzer/model/CommunicationModel.java
+++ b/src/main/java/com/hlag/tools/commvis/analyzer/model/CommunicationModel.java
@@ -3,9 +3,11 @@ package com.hlag.tools.commvis.analyzer.model;
 import com.google.gson.annotations.SerializedName;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 
 import java.util.Collection;
+import java.util.HashSet;
 
 /**
  * Base class for the entire communication model, e.g. senders and receivers.
@@ -14,42 +16,53 @@ import java.util.Collection;
  * interface.
  */
 @Getter
-@AllArgsConstructor
+@RequiredArgsConstructor
 @ToString
 public class CommunicationModel {
     /**
      * Identifier for the current project, e.g. gitlab project id
      */
     @SerializedName(value="project_id")
-
-    private String projectId;
+    private final String projectId;
 
     /**
      * A name for the project. Just for information.
      */
-
     @SerializedName(value="project_name")
-    private String projectName;
+    private final String projectName;
+
+    @SerializedName(value="model_version")
+    private final String modelVersion;
 
     /**
      * All HTTP receiver endpoints.
      */
     @SerializedName(value="http_consumers")
-    private Collection<ISenderReceiverCommunication> httpConsumers;
+    private Collection<HttpConsumer> httpConsumers = new HashSet<>();
 
     /**
      * All HTTP producers.
      */
     @SerializedName(value="http_producers")
-    private Collection<ISenderReceiverCommunication> httpProducers;
+    private Collection<HttpProducer> httpProducers = new HashSet<>();
 
     /**
      * All JMS receivers.
      */
-
     @SerializedName(value="jms_consumers")
-    private Collection<ISenderReceiverCommunication> jmsConsumers;
+    private Collection<JmsReceiver> jmsConsumers = new HashSet<>();
 
+    public void addHttpConsumer(HttpConsumer consumer) {
+        httpConsumers.add(consumer);
+    }
+
+    public void addHttpProducer(HttpProducer producer) {
+        httpProducers.add(producer);
+    }
+
+    public void addJmsConsumer(JmsReceiver consumer) {
+        jmsConsumers.add(consumer);
+    }
 
     public void visit(AbstractCommunicationModelVisitor visitor) {
         visitor.visit(this);

--- a/src/main/java/com/hlag/tools/commvis/analyzer/model/CommunicationModel.java
+++ b/src/main/java/com/hlag/tools/commvis/analyzer/model/CommunicationModel.java
@@ -15,7 +15,6 @@ import java.util.HashSet;
  * The model is built by various services implementing the {@link com.hlag.tools.commvis.analyzer.service.IScannerService}
  * interface.
  */
-@Getter
 @RequiredArgsConstructor
 @ToString
 public class CommunicationModel {
@@ -38,29 +37,29 @@ public class CommunicationModel {
      * All HTTP receiver endpoints.
      */
     @SerializedName(value="http_consumers")
-    private Collection<HttpConsumer> httpConsumers = new HashSet<>();
+    private Collection<ISenderReceiverCommunication> httpConsumers = new HashSet<>();
 
     /**
      * All HTTP producers.
      */
     @SerializedName(value="http_producers")
-    private Collection<HttpProducer> httpProducers = new HashSet<>();
+    private Collection<ISenderReceiverCommunication> httpProducers = new HashSet<>();
 
     /**
      * All JMS receivers.
      */
     @SerializedName(value="jms_consumers")
-    private Collection<JmsReceiver> jmsConsumers = new HashSet<>();
+    private Collection<ISenderReceiverCommunication> jmsConsumers = new HashSet<>();
 
-    public void addHttpConsumer(HttpConsumer consumer) {
+    public void addHttpConsumer(ISenderReceiverCommunication consumer) {
         httpConsumers.add(consumer);
     }
 
-    public void addHttpProducer(HttpProducer producer) {
+    public void addHttpProducer(ISenderReceiverCommunication producer) {
         httpProducers.add(producer);
     }
 
-    public void addJmsConsumer(JmsReceiver consumer) {
+    public void addJmsConsumer(ISenderReceiverCommunication consumer) {
         jmsConsumers.add(consumer);
     }
 


### PR DESCRIPTION
# Description

Simplify the interface to add new endpoints. `addSenderReceiver(T endpoint)` should be sufficient.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
