### PR TITLE
fix: allow access to project id of model

### DIFF
--- a/src/main/java/com/hlag/tools/commvis/analyzer/model/CommunicationModel.java
+++ b/src/main/java/com/hlag/tools/commvis/analyzer/model/CommunicationModel.java
@@ -21,6 +21,7 @@ public class CommunicationModel {
     /**
      * Identifier for the current project, e.g. gitlab project id
      */
+    @Getter
     @SerializedName(value="project_id")
     private final String projectId;
 


### PR DESCRIPTION
# Description

The project id is shown in the external model. Thus allow access via getter.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
