### PR TITLE
feat: add method to identify matching HTTP consumer/producer

### DIFF
--- a/src/main/java/com/hlag/tools/commvis/analyzer/model/HttpConsumer.java
+++ b/src/main/java/com/hlag/tools/commvis/analyzer/model/HttpConsumer.java
@@ -24,6 +24,15 @@ public class HttpConsumer implements ISenderReceiverCommunication {
     @SerializedName(value="id")
     String id;
 
+    /**
+     *
+     * @param producer the producer tested
+     * @return {@code true} if this consumer is receives messages from the {@code producer}.
+     */
+    public boolean isProducedBy(HttpProducer producer) {
+        return type.equals(producer.getType()) && path.equals(producer.getPath());
+    }
+
     @Override
     public void visit(AbstractCommunicationModelVisitor visitor) {
         visitor.visit(this);

--- a/src/test/java/com/hlag/tools/commvis/analyzer/model/HttpConsumerTest.java
+++ b/src/test/java/com/hlag/tools/commvis/analyzer/model/HttpConsumerTest.java
@@ -1,6 +1,7 @@
 package com.hlag.tools.commvis.analyzer.model;
 
 import com.google.gson.annotations.SerializedName;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
@@ -8,6 +9,18 @@ import java.lang.reflect.Field;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class HttpConsumerTest {
+    private HttpConsumer consumer;
+    private final static String CLASS_NAME = "className";
+    private final static String METHOD_NAME = "methodName";
+    private final static String TYPE = "type";
+    private final static String PATH = "path";
+    private final static String ID = "id";
+
+    @BeforeEach
+    void init() {
+        consumer = new HttpConsumer(CLASS_NAME, METHOD_NAME, TYPE, PATH, ID);
+    }
+
     @Test
     void shouldHaveSerializedNameAnnotationOnFiled_toDecoupleTheFieldNameFromJson() {
         Field[] declaredFields = CommunicationModel.class.getDeclaredFields();
@@ -17,5 +30,32 @@ class HttpConsumerTest {
 
             assertThat(actualAnnotation).isNotNull();
         }
+    }
+
+    @Test
+    void shouldIdentifyMatchingConsumerAndProducer_whenIsProducedBy() {
+        HttpProducer givenProducer = new HttpProducer("x", "y", TYPE, PATH, "destinationId", "id1");
+
+        boolean actualMatching = consumer.isProducedBy(givenProducer);
+
+        assertThat(actualMatching).isTrue();
+    }
+
+    @Test
+    void shouldNotIdentifyMatchingConsumerAndProducer_whenIsProducedBy_givenPathIsDifferent() {
+        HttpProducer givenProducer = new HttpProducer("x", "y", TYPE, "my-path", "destinationId", "id1");
+
+        boolean actualMatching = consumer.isProducedBy(givenProducer);
+
+        assertThat(actualMatching).isFalse();
+    }
+
+    @Test
+    void shouldIdentifyMatchingConsumerAndProducer_whenIsProducedBy_givenTypeIsDifferent() {
+        HttpProducer givenProducer = new HttpProducer("x", "y", "my-type", PATH, "destinationId", "id1");
+
+        boolean actualMatching = consumer.isProducedBy(givenProducer);
+
+        assertThat(actualMatching).isFalse();
     }
 }


### PR DESCRIPTION
# Description

Adds a method `isProducedBy(HttpProducer)` to `HttpConsumer` to identify matching `HttpProducer`. Thus identifying the producers calling a consumer.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
