### PR TITLE
feat: add sns producer annotation

### DIFF
--- a/src/main/java/com/hlag/tools/commvis/analyzer/annotation/VisualizeSnsProducer.java
+++ b/src/main/java/com/hlag/tools/commvis/analyzer/annotation/VisualizeSnsProducer.java
@@ -1,21 +1,18 @@
 package com.hlag.tools.commvis.analyzer.annotation;
 
-import com.google.gson.annotations.SerializedName;
-import com.hlag.tools.commvis.analyzer.model.AbstractCommunicationModelVisitor;
-
 import java.lang.annotation.*;
 
 /**
- * Marks a producer for AWS SQS messages.
+ * Marks a producer for AWS SNS messages.
  */
-@Repeatable(VisualizeSqsProducers.class)
+@Repeatable(VisualizeSnsProducers.class)
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface VisualizeSqsProducer {
+public @interface VisualizeSnsProducer {
     /**
-     * @return name of the SQS queue messages are sent to
+     * @return name of the SNS topic messages are sent to
      */
-    String queueName();
+    String topicName();
 
     /**
      * @return the id of the project called, usually the Gitlab project id or similar

--- a/src/main/java/com/hlag/tools/commvis/analyzer/annotation/VisualizeSnsProducers.java
+++ b/src/main/java/com/hlag/tools/commvis/analyzer/annotation/VisualizeSnsProducers.java
@@ -1,0 +1,18 @@
+package com.hlag.tools.commvis.analyzer.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Used to group multiple {@link VisualizeSnsProducer} annotations on one element.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface VisualizeSnsProducers {
+    /**
+     * @return all grouped {@link VisualizeSnsProducer} annotations
+     */
+    VisualizeSnsProducer[] value();
+}

--- a/src/main/java/com/hlag/tools/commvis/analyzer/annotation/VisualizeSqsConsumer.java
+++ b/src/main/java/com/hlag/tools/commvis/analyzer/annotation/VisualizeSqsConsumer.java
@@ -1,13 +1,11 @@
 package com.hlag.tools.commvis.analyzer.annotation;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 
 /**
  * Annotated on methods to indicate that SQS messages are consumed.
  */
+@Repeatable(VisualizeSqsConsumers.class)
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface VisualizeSqsConsumer {

--- a/src/main/java/com/hlag/tools/commvis/analyzer/model/AbstractCommunicationModelVisitor.java
+++ b/src/main/java/com/hlag/tools/commvis/analyzer/model/AbstractCommunicationModelVisitor.java
@@ -13,4 +13,6 @@ public abstract class AbstractCommunicationModelVisitor {
 
     public abstract void visit(SqsConsumer sqsConsumer);
     public abstract void visit(SqsProducer sqsProducer);
+
+    public abstract void visit(SnsProducer snsProducer);
 }

--- a/src/main/java/com/hlag/tools/commvis/analyzer/model/CommunicationModel.java
+++ b/src/main/java/com/hlag/tools/commvis/analyzer/model/CommunicationModel.java
@@ -66,6 +66,12 @@ public class CommunicationModel {
     @SerializedName(value = "sqs_producers")
     private Collection<SqsProducer> sqsProducers = new HashSet<>();
 
+    /**
+     * All SNS producers.
+     */
+    @SerializedName(value = "sns_producers")
+    private Collection<SnsProducer> snsProducers = new HashSet<>();
+
     private CommunicationModel() {
         // for GSON deserialize
         projectId = NOT_SET;
@@ -84,6 +90,8 @@ public class CommunicationModel {
             sqsConsumers.add((SqsConsumer) endpoint);
         } else if (endpoint instanceof SqsProducer) {
             sqsProducers.add((SqsProducer) endpoint);
+        } else if (endpoint instanceof SnsProducer) {
+            snsProducers.add((SnsProducer) endpoint);
         } else {
             throw new IllegalStateException(String.format("We have no endpoints of type %s", endpoint.getClass().getCanonicalName()));
         }
@@ -97,5 +105,6 @@ public class CommunicationModel {
         jmsConsumers.forEach(e -> e.visit(visitor));
         sqsConsumers.forEach(e -> e.visit(visitor));
         sqsProducers.forEach(e -> e.visit(visitor));
+        snsProducers.forEach(e -> e.visit(visitor));
     }
 }

--- a/src/main/java/com/hlag/tools/commvis/analyzer/model/EndpointFactory.java
+++ b/src/main/java/com/hlag/tools/commvis/analyzer/model/EndpointFactory.java
@@ -1,8 +1,11 @@
 package com.hlag.tools.commvis.analyzer.model;
 
+import com.hlag.tools.commvis.analyzer.annotation.VisualizeSnsProducer;
 import com.hlag.tools.commvis.analyzer.port.IIdentityGenerator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
 
 @Component
 @RequiredArgsConstructor
@@ -27,5 +30,9 @@ public class EndpointFactory {
 
     public SqsProducer createSqsProducer(String className, String methodName, String queueName, String destinationProjectId) {
         return new SqsProducer(className, methodName, queueName, destinationProjectId, identityGenerator.generateUniqueId());
+    }
+
+    public SnsProducer createSnsProducer(VisualizeSnsProducer annotation, Method method) {
+        return new SnsProducer(method.getDeclaringClass().getCanonicalName(), method.getName(), annotation.topicName(), annotation.projectId(), identityGenerator.generateUniqueId());
     }
 }

--- a/src/main/java/com/hlag/tools/commvis/analyzer/model/SnsProducer.java
+++ b/src/main/java/com/hlag/tools/commvis/analyzer/model/SnsProducer.java
@@ -1,0 +1,48 @@
+package com.hlag.tools.commvis.analyzer.model;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+
+/**
+ * A producer for SNS messages.
+ */
+@Value
+@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
+public class SnsProducer implements ISenderReceiverCommunication, IProducer {
+    /**
+     * the class name where the producer was found.
+     */
+    @SerializedName(value="class_name")
+    String className;
+
+    /**
+     * the method name were the producer was found.
+     */
+    @SerializedName(value="method_name")
+    String methodName;
+
+    /**
+     * the topic the messages are sent to.
+     */
+    @SerializedName(value="topic_name")
+    String topicName;
+
+    /**
+     * The project id of the referenced project.
+     */
+    @SerializedName(value="destination_project_id")
+    String destinationProjectId;
+
+    /**
+     * internal id of this node
+     */
+    @SerializedName(value="id")
+    String id;
+
+    @Override
+    public void visit(AbstractCommunicationModelVisitor visitor) {
+        visitor.visit(this);
+    }
+}

--- a/src/test/java/com/hlag/tools/commvis/analyzer/model/EndpointFactoryTest.java
+++ b/src/test/java/com/hlag/tools/commvis/analyzer/model/EndpointFactoryTest.java
@@ -1,5 +1,6 @@
 package com.hlag.tools.commvis.analyzer.model;
 
+import com.hlag.tools.commvis.analyzer.annotation.VisualizeSnsProducer;
 import com.hlag.tools.commvis.analyzer.port.IIdentityGenerator;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -11,6 +12,12 @@ import org.mockito.MockitoAnnotations;
 
 class EndpointFactoryTest {
     private static final String FIXED_ID = "MY-UNIQUE-ID";
+
+    private static class TestProducersAndConsumers {
+        @VisualizeSnsProducer(topicName = "topic", projectId = "4711")
+        public void produceSnsMessage() {
+        }
+    }
 
     @Mock
     private IIdentityGenerator identityGenerator;
@@ -77,5 +84,16 @@ class EndpointFactoryTest {
         Assertions.assertThat(actualSqsProducer.getQueueName()).isEqualTo("queueName");
         Assertions.assertThat(actualSqsProducer.getDestinationProjectId()).isEqualTo("destinationProjectId");
         Assertions.assertThat(actualSqsProducer.getId()).isEqualTo(FIXED_ID);
+    }
+
+    @Test
+    void shouldSetAllFields_whenCreateSnsProducer() throws NoSuchMethodException {
+        SnsProducer actualSnsProducer = factory.createSnsProducer(TestProducersAndConsumers.class.getDeclaredMethod("produceSnsMessage").getAnnotationsByType(VisualizeSnsProducer.class)[0], TestProducersAndConsumers.class.getDeclaredMethod("produceSnsMessage"));
+
+        Assertions.assertThat(actualSnsProducer.getClassName()).isEqualTo("com.hlag.tools.commvis.analyzer.model.EndpointFactoryTest.TestProducersAndConsumers");
+        Assertions.assertThat(actualSnsProducer.getMethodName()).isEqualTo("produceSnsMessage");
+        Assertions.assertThat(actualSnsProducer.getTopicName()).isEqualTo("topic");
+        Assertions.assertThat(actualSnsProducer.getDestinationProjectId()).isEqualTo("4711");
+        Assertions.assertThat(actualSnsProducer.getId()).isEqualTo(FIXED_ID);
     }
 }


### PR DESCRIPTION
# Description

Adds the `VisualizeSnsProducer` annotation to mark methods sending messages to SNS.
Fixes missing annotations on the other annotations, e.g. `@Retention(RetentionPolicy.RUNTIME)`.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
