### PR TITLE
feat: add Kafka consumer/producer annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ This project contains some API classes to allow users to define their own scanne
     <groupId>com.hlag.tools.commvis</groupId>
     <artifactId>api</artifactId>
     <version>2.7.0</version>
-    <scope>provided</scope>
 </dependency>
 ```
 ## Writing A User-Defined Scanner

--- a/src/main/java/com/hlag/tools/commvis/analyzer/annotation/VisualizeKafkaConsumer.java
+++ b/src/main/java/com/hlag/tools/commvis/analyzer/annotation/VisualizeKafkaConsumer.java
@@ -1,0 +1,21 @@
+package com.hlag.tools.commvis.analyzer.annotation;
+
+import java.lang.annotation.*;
+
+/**
+ * Annotated on methods to indicate that Kafka messages are consumed.
+ */
+@Repeatable(VisualizeKafkaConsumers.class)
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface VisualizeKafkaConsumer {
+    /**
+     * @return name of the Kafka topic messages are received from
+     */
+    String topicName();
+
+    /**
+     * @return the name of the project the messages are received from. Just for a better visibility in the code. The value isn't used.
+     */
+    String projectName() default "";
+}

--- a/src/main/java/com/hlag/tools/commvis/analyzer/annotation/VisualizeKafkaConsumers.java
+++ b/src/main/java/com/hlag/tools/commvis/analyzer/annotation/VisualizeKafkaConsumers.java
@@ -1,0 +1,18 @@
+package com.hlag.tools.commvis.analyzer.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+/**
+ * Used to group multiple {@link VisualizeKafkaConsumer} annotations on one element.
+ */
+public @interface VisualizeKafkaConsumers {
+    /**
+     * @return all grouped {@link VisualizeKafkaConsumer} annotations
+     */
+    VisualizeKafkaConsumer[] value();
+}

--- a/src/main/java/com/hlag/tools/commvis/analyzer/annotation/VisualizeKafkaProducer.java
+++ b/src/main/java/com/hlag/tools/commvis/analyzer/annotation/VisualizeKafkaProducer.java
@@ -1,0 +1,26 @@
+package com.hlag.tools.commvis.analyzer.annotation;
+
+import java.lang.annotation.*;
+
+/**
+ * Marks a producer for Kafka messages.
+ */
+@Repeatable(VisualizeKafkaProducers.class)
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface VisualizeKafkaProducer {
+    /**
+     * @return name of the topic messages are sent to
+     */
+    String topicName();
+
+    /**
+     * @return the id of the project called, usually the Gitlab project id or similar
+     */
+    String projectId();
+
+    /**
+     * @return the name of the project called. Just for a better visibility in the code. The value isn't used.
+     */
+    String projectName() default "";
+}

--- a/src/main/java/com/hlag/tools/commvis/analyzer/annotation/VisualizeKafkaProducers.java
+++ b/src/main/java/com/hlag/tools/commvis/analyzer/annotation/VisualizeKafkaProducers.java
@@ -1,0 +1,18 @@
+package com.hlag.tools.commvis.analyzer.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Used to group multiple {@link VisualizeKafkaProducer} annotations on one element.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface VisualizeKafkaProducers {
+    /**
+     * @return all grouped {@link VisualizeKafkaProducer} annotations
+     */
+    VisualizeKafkaProducer[] value();
+}

--- a/src/main/java/com/hlag/tools/commvis/analyzer/model/AbstractCommunicationModelVisitor.java
+++ b/src/main/java/com/hlag/tools/commvis/analyzer/model/AbstractCommunicationModelVisitor.java
@@ -16,4 +16,7 @@ public abstract class AbstractCommunicationModelVisitor {
     public abstract void visit(SqsProducer sqsProducer);
 
     public abstract void visit(SnsProducer snsProducer);
+
+    public abstract void visit(KafkaProducer kafkaProducer);
+    public abstract void visit(KafkaConsumer kafkaConsumer);
 }

--- a/src/main/java/com/hlag/tools/commvis/analyzer/model/CommunicationModel.java
+++ b/src/main/java/com/hlag/tools/commvis/analyzer/model/CommunicationModel.java
@@ -78,6 +78,18 @@ public class CommunicationModel {
     @SerializedName(value = "sns_producers")
     private Collection<SnsProducer> snsProducers = new HashSet<>();
 
+    /**
+     * All SNS producers.
+     */
+    @SerializedName(value = "kafka_producers")
+    private Collection<KafkaProducer> kafkaProducers = new HashSet<>();
+
+    /**
+     * All SQS consumers.
+     */
+    @SerializedName(value = "kafka_consumers")
+    private Collection<KafkaConsumer> kafkaConsumers = new HashSet<>();
+
     private CommunicationModel() {
         // for GSON deserialize
         projectId = NOT_SET;
@@ -100,6 +112,10 @@ public class CommunicationModel {
             snsProducers.add((SnsProducer) endpoint);
         } else if (endpoint instanceof SqsViaSnsConsumer) {
             sqsViaSnsConsumers.add((SqsViaSnsConsumer) endpoint);
+        } else if (endpoint instanceof KafkaProducer) {
+            kafkaProducers.add((KafkaProducer) endpoint);
+        } else if (endpoint instanceof KafkaConsumer) {
+            kafkaConsumers.add((KafkaConsumer) endpoint);
         } else {
             throw new IllegalStateException(String.format("We have no endpoints of type %s", endpoint.getClass().getCanonicalName()));
         }
@@ -115,5 +131,7 @@ public class CommunicationModel {
         sqsProducers.forEach(e -> e.visit(visitor));
         snsProducers.forEach(e -> e.visit(visitor));
         sqsViaSnsConsumers.forEach(e -> e.visit(visitor));
+        kafkaProducers.forEach(e -> e.visit(visitor));
+        kafkaConsumers.forEach(e -> e.visit(visitor));
     }
 }

--- a/src/main/java/com/hlag/tools/commvis/analyzer/model/EndpointFactory.java
+++ b/src/main/java/com/hlag/tools/commvis/analyzer/model/EndpointFactory.java
@@ -1,5 +1,7 @@
 package com.hlag.tools.commvis.analyzer.model;
 
+import com.hlag.tools.commvis.analyzer.annotation.VisualizeKafkaConsumer;
+import com.hlag.tools.commvis.analyzer.annotation.VisualizeKafkaProducer;
 import com.hlag.tools.commvis.analyzer.annotation.VisualizeSnsProducer;
 import com.hlag.tools.commvis.analyzer.annotation.VisualizeSqsViaSnsConsumer;
 import com.hlag.tools.commvis.analyzer.port.IIdentityGenerator;
@@ -39,5 +41,13 @@ public class EndpointFactory {
 
     public SnsProducer createSnsProducer(VisualizeSnsProducer annotation, Method method) {
         return new SnsProducer(method.getDeclaringClass().getCanonicalName(), method.getName(), annotation.topicName(), annotation.projectId(), identityGenerator.generateUniqueId());
+    }
+
+    public KafkaProducer createKafkaProducer(VisualizeKafkaProducer annotation, Method method) {
+        return new KafkaProducer(method.getDeclaringClass().getCanonicalName(), method.getName(), annotation.topicName(), annotation.projectId(), identityGenerator.generateUniqueId());
+    }
+
+    public KafkaConsumer createKafkaConsumer(VisualizeKafkaConsumer annotation, Method method) {
+        return new KafkaConsumer(method.getDeclaringClass().getCanonicalName(), method.getName(), annotation.topicName(), identityGenerator.generateUniqueId());
     }
 }

--- a/src/main/java/com/hlag/tools/commvis/analyzer/model/KafkaConsumer.java
+++ b/src/main/java/com/hlag/tools/commvis/analyzer/model/KafkaConsumer.java
@@ -1,0 +1,41 @@
+package com.hlag.tools.commvis.analyzer.model;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+
+/**
+ * A receiver for Kafka messages.
+ */
+@Value
+@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
+public class KafkaConsumer implements ISenderReceiverCommunication, IConsumer {
+    @SerializedName(value="class_name")
+    String className;
+
+    @SerializedName(value="method_name")
+    String methodName;
+
+    @SerializedName(value="topic_name")
+    String topicName;
+
+    @SerializedName(value="id")
+    String id;
+
+    @Override
+    public void visit(AbstractCommunicationModelVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public boolean isProducedBy(IProducer producer) {
+        if (producer instanceof KafkaProducer) {
+            KafkaProducer kafkaProducer = (KafkaProducer) producer;
+
+            return topicName.equals(kafkaProducer.getTopicName());
+        }
+
+        return false;
+    }
+}

--- a/src/main/java/com/hlag/tools/commvis/analyzer/model/KafkaProducer.java
+++ b/src/main/java/com/hlag/tools/commvis/analyzer/model/KafkaProducer.java
@@ -1,0 +1,48 @@
+package com.hlag.tools.commvis.analyzer.model;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+
+/**
+ * A producer for Kafka messages.
+ */
+@Value
+@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
+public class KafkaProducer implements ISenderReceiverCommunication, IProducer {
+    /**
+     * the class name where the producer was found.
+     */
+    @SerializedName(value="class_name")
+    String className;
+
+    /**
+     * the method name were the producer was found.
+     */
+    @SerializedName(value="method_name")
+    String methodName;
+
+    /**
+     * the topic the messages are sent to.
+     */
+    @SerializedName(value="topic_name")
+    String topicName;
+
+    /**
+     * The project id of the referenced project.
+     */
+    @SerializedName(value="destination_project_id")
+    String destinationProjectId;
+
+    /**
+     * internal id of this node
+     */
+    @SerializedName(value="id")
+    String id;
+
+    @Override
+    public void visit(AbstractCommunicationModelVisitor visitor) {
+        visitor.visit(this);
+    }
+}

--- a/src/test/java/com/hlag/tools/commvis/analyzer/model/KafkaConsumerTest.java
+++ b/src/test/java/com/hlag/tools/commvis/analyzer/model/KafkaConsumerTest.java
@@ -1,0 +1,46 @@
+package com.hlag.tools.commvis.analyzer.model;
+
+import com.google.gson.annotations.SerializedName;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class KafkaConsumerTest {
+    private KafkaConsumer kafkaConsumer;
+
+    @BeforeEach
+    void init() {
+        kafkaConsumer = new KafkaConsumer("class", "method", "queue", "id");
+    }
+    @Test
+    void shouldHaveSerializedNameAnnotationOnFiled_toDecoupleTheFieldNameFromJson() {
+        Field[] declaredFields = KafkaConsumer.class.getDeclaredFields();
+
+        for (Field f : declaredFields) {
+            SerializedName actualAnnotation = f.getAnnotation(SerializedName.class);
+
+            assertThat(actualAnnotation).withFailMessage(() -> String.format("Field %s has no @SerializedName annotation.", f.getName())).isNotNull();
+        }
+    }
+
+    @Test
+    void shouldReturnTrue_whenIsProducedBy_givenProducerIsForSameTopic() {
+        KafkaProducer givenProducer = new KafkaProducer("class1", "method1", "topic", "destinationProject", "id1");
+
+        boolean actualIsProducedBy = kafkaConsumer.isProducedBy(givenProducer);
+
+        assertThat(actualIsProducedBy).isTrue();
+    }
+
+    @Test
+    void shouldReturnFalse_whenIsProducedBy_givenProducerIsForOtherTopic() {
+        KafkaProducer givenProducer = new KafkaProducer("class1", "method1", "topic-other", "destinationProject", "id1");
+
+        boolean actualIsProducedBy = kafkaConsumer.isProducedBy(givenProducer);
+
+        assertThat(actualIsProducedBy).isFalse();
+    }
+}

--- a/src/test/java/com/hlag/tools/commvis/analyzer/model/KafkaConsumerTest.java
+++ b/src/test/java/com/hlag/tools/commvis/analyzer/model/KafkaConsumerTest.java
@@ -13,7 +13,7 @@ class KafkaConsumerTest {
 
     @BeforeEach
     void init() {
-        kafkaConsumer = new KafkaConsumer("class", "method", "queue", "id");
+        kafkaConsumer = new KafkaConsumer("class", "method", "topic", "id");
     }
     @Test
     void shouldHaveSerializedNameAnnotationOnFiled_toDecoupleTheFieldNameFromJson() {

--- a/src/test/java/com/hlag/tools/commvis/analyzer/model/KafkaProducerTest.java
+++ b/src/test/java/com/hlag/tools/commvis/analyzer/model/KafkaProducerTest.java
@@ -1,0 +1,21 @@
+package com.hlag.tools.commvis.analyzer.model;
+
+import com.google.gson.annotations.SerializedName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class KafkaProducerTest {
+    @Test
+    void shouldHaveSerializedNameAnnotationOnFiled_toDecoupleTheFieldNameFromJson() {
+        Field[] declaredFields = SnsProducer.class.getDeclaredFields();
+
+        for (Field f : declaredFields) {
+            SerializedName actualAnnotation = f.getAnnotation(SerializedName.class);
+
+            assertThat(actualAnnotation).withFailMessage(() -> String.format("Field %s has no @SerializedName annotation.", f.getName())).isNotNull();
+        }
+    }
+}

--- a/src/test/java/com/hlag/tools/commvis/analyzer/model/SnsProducerTest.java
+++ b/src/test/java/com/hlag/tools/commvis/analyzer/model/SnsProducerTest.java
@@ -1,0 +1,21 @@
+package com.hlag.tools.commvis.analyzer.model;
+
+import com.google.gson.annotations.SerializedName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SnsProducerTest {
+    @Test
+    void shouldHaveSerializedNameAnnotationOnFiled_toDecoupleTheFieldNameFromJson() {
+        Field[] declaredFields = SnsProducer.class.getDeclaredFields();
+
+        for (Field f : declaredFields) {
+            SerializedName actualAnnotation = f.getAnnotation(SerializedName.class);
+
+            assertThat(actualAnnotation).withFailMessage(() -> String.format("Field %s has no @SerializedName annotation.", f.getName())).isNotNull();
+        }
+    }
+}


### PR DESCRIPTION
# Description

Adds annotations to mark Kafka consumers and producers. `VisualizeKafkaConsumer` and `VisualizeKafkaProducer`.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
