### PR TITLE
ci: install Java 17 for release-please

### DIFF
--- a/.github/workflows/semantic-release-dry-run.yml
+++ b/.github/workflows/semantic-release-dry-run.yml
@@ -37,4 +37,4 @@ jobs:
           SERVER_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
           GPG_PRIVATE_KEY: ${{ secrets.GPG_SIGNING_KEY }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-        run: unset GITHUB_ACTIONS && npx --prefix .release/ semantic-release --dry-run --no-ci --debug
+        run: java --version && unset GITHUB_ACTIONS && npx --prefix .release/ semantic-release --dry-run --no-ci --debug

--- a/.github/workflows/semantic-release-dry-run.yml
+++ b/.github/workflows/semantic-release-dry-run.yml
@@ -15,6 +15,13 @@ jobs:
         with:
           ref: release-dry-run
 
+      - name: Set up JDK 17
+        uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93 # v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: maven
+          
       - name: Setup Node.js
         uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4
         with:

--- a/.github/workflows/semantic-release-dry-run.yml
+++ b/.github/workflows/semantic-release-dry-run.yml
@@ -37,4 +37,4 @@ jobs:
           SERVER_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
           GPG_PRIVATE_KEY: ${{ secrets.GPG_SIGNING_KEY }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-        run: java --version && unset GITHUB_ACTIONS && npx --prefix .release/ semantic-release --dry-run --no-ci --debug
+        run: unset GITHUB_ACTIONS && npx --prefix .release/ semantic-release --dry-run --no-ci --debug


### PR DESCRIPTION
The release workflow failed with `Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.1:compile (default-compile) on project api: Fatal error compiling: error: invalid target release: 17 -> [Help 1]`. It seems that the Java version used is not compatible with Java 17.